### PR TITLE
Oceanspace v2 in middle of

### DIFF
--- a/Apps/HistogramSize/HistogramSize.cpp
+++ b/Apps/HistogramSize/HistogramSize.cpp
@@ -11,8 +11,6 @@
 #include <fstream>
 #include <map>
 #include <vector>
-
-
 #include "MemoryDebug.h"
 
 
@@ -23,6 +21,7 @@ using namespace std;
 #include "KKStr.h"
 #include "MorphOpStretcher.h"
 #include "MsgQueue.h"
+#include "Option.h"
 #include "OSservices.h"
 using namespace  KKB;
 
@@ -675,24 +674,21 @@ using namespace  KKLSC;
 
 
 
-
-
-
 bool  OkToRenameFile (const KKStr&  fn)
 {
-  kkint32 idx = fn.Find ("_2013");
+  auto idx = fn.Find ("_2013");
   if  (idx < 0)
     idx = fn.Find ("_2012");
 
   if  (idx < 0)  return false;
 
-  KKStr  part1 = fn.SubStrPart (0, idx - 1);
+  KKStr  part1 = fn.SubStrSeg (0, idx);
   KKStr  rest = fn.SubStrPart (idx + 1);
 
   if  (rest[8] != '-')
     return false;
 
-  KKStr  dateStr = rest.SubStrPart (0, 7);
+  KKStr  dateStr = rest.SubStrSeg (0, 8);
   rest = rest.SubStrPart (9);
 
   if  (rest.SubStrPart (6) == ".lsc")
@@ -701,7 +697,7 @@ bool  OkToRenameFile (const KKStr&  fn)
   if  (rest[6] != '_')
     return false;
 
-  KKStr  timeStr = rest.SubStrPart (0, 5);
+  KKStr  timeStr = rest.SubStrSeg (0, 6);
   rest = rest.SubStrPart (7);
 
   if  (isdigit (rest[0])  &&  isdigit (rest[1])  &&  (rest.SubStrPart (2) == ".lsc"))

--- a/LarcosLibraries/LarcosCounterManaged/UmiTrainingConfiguration.cpp
+++ b/LarcosLibraries/LarcosCounterManaged/UmiTrainingConfiguration.cpp
@@ -8,11 +8,8 @@
 #include <iostream>
 #include <ostream>
 #include <string>
-#include <strstream>
 #include <vector>
 #include "MemoryDebug.h"
-
-
 #include "KKBaseTypes.h"
 #include "..\\KKBase\\GoalKeeper.h"
 #include "KKStr.h"
@@ -70,13 +67,13 @@ UmiTrainingConfiguration::UmiTrainingConfiguration (String^                  _co
   if  (_initialOperatingParameters != nullptr)
     op = _initialOperatingParameters->UnManagedClass ();
 
-  std::strstream  logStr;
+  std::stringstream  logStr;
   KKStr  configFileName = UmiKKStr::SystemStringToKKStr (_configFileName);
   config = new LarcosTrainingConfiguration ();
   config->Load (configFileName, op, true, log->Log ());
   valid = gcnew System::Boolean (config->FormatGood ());
   if  (!config->FormatGood ())
-     loadLogStream = gcnew String (logStr.str ());
+     loadLogStream = gcnew String (logStr.str ().c_str ());
 }
 
 
@@ -303,21 +300,21 @@ String^   UmiTrainingConfiguration::GetSettingValue (String^ sectionName,
 
 Dictionary<String^,String^>^   UmiTrainingConfiguration::GetSettingValues (String^  _sectionName)
 {
-  kkint32  sectionNum =  config->SectionNum (UmiKKStr::SystemStringToKKStr (_sectionName));
-  if  (sectionNum < 0)
+  auto  sectionNum =  config->SectionNum (UmiKKStr::SystemStringToKKStr (_sectionName));
+  if  (!sectionNum)
     return nullptr;
 
   Dictionary<String^,String^>^ settings = gcnew Dictionary<String^,String^> ();
 
-  kkint32 settingNum = 0;
+  kkuint32 settingNum = 0;
   do
   {
     kkint32  lineNum = 0;
-    KKStrConstPtr   settingValue = config->SettingValue (sectionNum, settingNum, lineNum);
+    KKStrConstPtr   settingValue = config->SettingValue (sectionNum.value (), settingNum, lineNum);
     if  (settingValue == NULL)
       break;
 
-    KKStrConstPtr   settingName = config->SettingName (sectionNum, settingNum);
+    KKStrConstPtr   settingName = config->SettingName (sectionNum.value (), settingNum);
     if  (settingName == NULL)
       break;
 

--- a/LarcosLibraries/LarcosCounterUnManaged/CameraFrameBuffer.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/CameraFrameBuffer.cpp
@@ -35,8 +35,8 @@ using  namespace  LarcosCounterUnManaged;
 
 CameraFrameBuffer::CameraFrameBuffer (LarcosCounterManagerPtr _manager,
                                       const KKStr&            _name,        /* Name of buffer, must be unique */
-                                      kkint32                 _bufferSize,
-                                      kkint32                 _maxNumOfBuffers,
+                                      kkuint32                _bufferSize,
+                                      kkuint32                _maxNumOfBuffers,
                                       kkint32                 _frameHeight,
                                       kkint32                 _frameWidth,
                                       bool                    _dataIsToBeCounted,
@@ -244,9 +244,9 @@ void  CameraFrameBuffer::ThrowOutOldestOccupiedBuffer ()
 
 
 
-void  CameraFrameBuffer::IncreaseBufferSize (kkint32 numNewFrameBuffers)
+void  CameraFrameBuffer::IncreaseBufferSize (kkuint32 numNewFrameBuffers)
 {
-  for  (kkint32 x = 0;  x < numNewFrameBuffers;  ++x)
+  for  (kkuint32 x = 0;  x < numNewFrameBuffers;  ++x)
   {
     CameraFramePtr  frame = new CameraFrame (frameHeight, frameWidth);
     frame->Processed            (false);

--- a/LarcosLibraries/LarcosCounterUnManaged/CameraFrameBuffer.h
+++ b/LarcosLibraries/LarcosCounterUnManaged/CameraFrameBuffer.h
@@ -82,8 +82,8 @@ namespace LarcosCounterUnManaged
 
     CameraFrameBuffer (LarcosCounterManagerPtr _manager,
                        const KKStr&            _name,
-                       kkint32                 _bufferSize,
-                       kkint32                 _maxNumOfBuffers,
+                       kkuint32                _bufferSize,
+                       kkuint32                _maxNumOfBuffers,
                        kkint32                 _frameHeight,
                        kkint32                 _frameWidth,
                        bool                    _dataIsToBeCounted,
@@ -99,7 +99,7 @@ namespace LarcosCounterUnManaged
     bool                 DataIsToBeCounted              () const {return dataIsToBeCounted;}
     kkint32              FrameHeight                    () const {return frameHeight;}
     kkint32              FrameWidth                     () const {return frameWidth;}
-    kkint32              MaxNumOfBuffers                () const {return maxNumOfBuffers;}
+    kkuint32             MaxNumOfBuffers                () const {return maxNumOfBuffers;}
     kkint64              NextFrameSeqNum                () const {return nextFrameSeqNum;}
     kkint32              NumAvailable                   () const;
     kkint32              NumWaitingToProcess            () const;
@@ -184,7 +184,7 @@ namespace LarcosCounterUnManaged
     /**@brief  Call this method when ever FlatField is enabled and/or ScanRate is changed. */
     void  ComputeFlatFeildSamplingInterval ();
 
-    void  IncreaseBufferSize (kkint32 numNewFrameBuffers);
+    void  IncreaseBufferSize (kkuint32 numNewFrameBuffers);
 
     void  LastFramesAllocate ();
 
@@ -235,7 +235,7 @@ namespace LarcosCounterUnManaged
 
     LarcosCounterManagerPtr manager;
 
-    kkint32                 maxNumOfBuffers;
+    kkuint32                maxNumOfBuffers;
     KKStr                   name;                       /**< Name of camera buffer, needs to be unique amongst all camera buffer instances. */
     kkint64                 nextFrameSeqNum;
     kkint32                 physicalFramesDropped;

--- a/LarcosLibraries/LarcosCounterUnManaged/FeatureFileIOKK.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/FeatureFileIOKK.cpp
@@ -250,7 +250,7 @@ LarcosFeatureVectorListPtr  FeatureFileIOKK::LoadFile (const KKStr&      _fileNa
                                                        FileDescConstPtr  _fileDesc,
                                                        MLClassList&      _classes, 
                                                        istream&          _in,
-                                                       kkint32           _maxCount,    // Maximum # images to load,  less than '0'  indicates all.
+                                                       OptionUInt32      _maxCount,
                                                        VolConstBool&     _cancelFlag,
                                                        bool&             _changesMade,
                                                        KKStr&            _errorMessage,
@@ -259,8 +259,7 @@ LarcosFeatureVectorListPtr  FeatureFileIOKK::LoadFile (const KKStr&      _fileNa
 {
   _log.Level (10) << "FeatureFileIOKK::LoadFile   Loading file[" << _fileName << "]." << endl;
   _log.Flush ();
-
-
+  
   VectorInt  featureFieldIndexTable;
 
   bool eof = false;
@@ -321,15 +320,17 @@ LarcosFeatureVectorListPtr  FeatureFileIOKK::LoadFile (const KKStr&      _fileNa
 
   KKStr field (128);
 
+  kkuint32 maxToLoad = _maxCount ? _maxCount.value () : uint32_max;
+
   GetToken (_in, ",\t", field, eof, eol);
-  while  ((!eof)   &&  (!_cancelFlag)   &&  (((kkint32)examples->size () < _maxCount)  ||  (_maxCount < 0)))
+  while  ((!eof)  &&  (!_cancelFlag)  &&  (examples->QueueSize () < maxToLoad))
   {
     if  (eol)
     {
       // We must have a blank line.  There is nothing to do in this case.
     }
 
-    else if  (field.SubStrPart (0, 1) == "//")
+    else if  (field.StartsWith ("//"))
     {
       // We are looking at a comment line.  Will skip to end of line
       while  ((!eol)  &&  (!eof))

--- a/LarcosLibraries/LarcosCounterUnManaged/FeatureFileIOKK.h
+++ b/LarcosLibraries/LarcosCounterUnManaged/FeatureFileIOKK.h
@@ -47,19 +47,19 @@ namespace LarcosCounterUnManaged
                                             kkint32&        _estSize,
                                             KKStr&          _errorMessage,
                                             RunLog&         _runLog
-                                           );
+                                           ) override;
 
 
     virtual  LarcosFeatureVectorListPtr  LoadFile (const KKStr&      _fileName,
                                                    FileDescConstPtr  _fileDesc,
                                                    MLClassList&      _classes, 
                                                    std::istream&     _in,
-                                                   kkint32           _maxCount,    // Maximum # images to load.
+                                                   OptionUInt32      _maxCount,    // Maximum # images to load.
                                                    VolConstBool&     _cancelFlag,
                                                    bool&             _changesMade,
                                                    KKStr&            _errorMessage,
                                                    RunLog&           _log
-                                                  );
+                                                  )  override;
 
 
     virtual  void   SaveFile (FeatureVectorList&    _data,
@@ -71,7 +71,7 @@ namespace LarcosCounterUnManaged
                               bool&                 _successful,
                               KKStr&                _errorMessage,
                               RunLog&               _log
-                             );
+                             )  override;
 
 
     static  FeatureFileIOKKPtr  Driver () {return driver;}

--- a/LarcosLibraries/LarcosCounterUnManaged/LarcosCounterManager.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/LarcosCounterManager.cpp
@@ -285,7 +285,6 @@ void  LarcosCounterManager::Initialize ()
 
 
 
-
 KKStr  LarcosCounterManager::LarcosVersionNumber ()
 {
 /*  KKStr  dateStr = __DATE__;

--- a/LarcosLibraries/LarcosCounterUnManaged/LarcosCounterManager.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/LarcosCounterManager.cpp
@@ -577,7 +577,7 @@ KKStr  LarcosCounterManager::GetNextControlNumber ()
 
     kkint32  lastSeqNum = lastControlNumber.SubStrPart (x).ToInt32 ();
 
-    KKStr  firstPart = lastControlNumber.SubStrPart (0, x - 1);
+    KKStr  firstPart = lastControlNumber.SubStrSeg (0, x);
     if  (firstPart.LastChar () == '_')
       firstPart.ChopLastChar ();
 

--- a/LarcosLibraries/LarcosCounterUnManaged/LarcosFeatureVector.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/LarcosFeatureVector.cpp
@@ -543,7 +543,7 @@ LarcosFeatureVectorListPtr  LarcosFeatureVectorList::DuplicateListAndContents ()
 {
   LarcosFeatureVectorListPtr  copyiedList = new LarcosFeatureVectorList (FileDesc (), true);
 
-  for  (kkint32 idx = 0;  idx < QueueSize ();  idx++)
+  for  (kkuint32 idx = 0;  idx < QueueSize ();  idx++)
   {
     LarcosFeatureVectorPtr  curImage = (LarcosFeatureVectorPtr)IdxToPtr (idx);
     copyiedList->PushOnBack (new LarcosFeatureVector (*curImage));

--- a/LarcosLibraries/LarcosCounterUnManaged/ParticleEntry.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/ParticleEntry.cpp
@@ -3,7 +3,6 @@
  * For conditions of distribution and use, see copyright notice in KKLineScanner.h
  */
 #include "FirstIncludes.h"
-
 #include <errno.h>
 #include <fstream>
 #include <istream>
@@ -13,9 +12,9 @@
 #include "MemoryDebug.h"
 using namespace std;
 
-
 #include "KKBaseTypes.h"
 #include "ImageIO.h"
+#include "Option.h"
 #include "OSservices.h"
 #include "Raster.h"
 using namespace KKB;
@@ -23,9 +22,9 @@ using namespace KKB;
 #include "MLClass.h"
 using namespace KKMLL;
 
-
 #include "ParticleEntry.h"
 using  namespace  LarcosCounterUnManaged;
+
 
 
 ParticleEntry::ParticleEntry ():
@@ -44,6 +43,7 @@ ParticleEntry::ParticleEntry ():
     featureVector       (NULL)
 {
 }
+
 
 
 ParticleEntry::ParticleEntry (const ParticleEntry&  _entry):
@@ -96,6 +96,7 @@ ParticleEntry::ParticleEntry (const KKStr&  _scannerFileRootName,
 }
 
 
+
 ParticleEntry::~ParticleEntry ()
 {
   delete  featureVector;
@@ -143,7 +144,6 @@ void  ParticleEntry::Assign (const ParticleEntry&   _entry)
 
 
 
-
 bool  ParticleEntry::ExactMatch (kkint32  _scannerRow,
                                  kkint16  _scannerCol,
                                  kkint16  _height,
@@ -158,14 +158,12 @@ bool  ParticleEntry::ExactMatch (kkint32  _scannerRow,
 
 
 
-
 FeatureVectorPtr  ParticleEntry::TakeOwnershipOfFeatureVector ()
 {
   FeatureVectorPtr  tempFV = featureVector;
   featureVector = NULL;
   return  tempFV;
 }
-
 
 
 
@@ -198,6 +196,7 @@ void  ParticleEntry::Assign (const KKStr& _scannerFileRootName,
 }
 
 
+
 ParticleEntryList::ParticleEntryList (bool _owner):
    KKQueue<ParticleEntry> (_owner),
    baseScannerName        (""),
@@ -228,6 +227,7 @@ ParticleEntryList::ParticleEntryList (bool _owner):
 { 
   SetDefaultFieldIndexs ();
 }
+
 
 
 ParticleEntryList::ParticleEntryList (const ParticleEntryList&  _list):
@@ -301,13 +301,10 @@ ParticleEntryList::ParticleEntryList (const KKStr&  _scannerFileName,
 }
 
 
-
-
  
 ParticleEntryList::~ParticleEntryList ()
 {
 }
-
 
 
 
@@ -343,10 +340,9 @@ void  ParticleEntryList::SplitIntoNameAndData (const KKStr&  line,
     return;
   }
 
-  name  = line.SubStrPart (0, idx.value () - 1);
-  value = line.SubStrPart (idx.value () + 1);
+  name  = line.SubStrSeg (0, idx);
+  value = line.SubStrPart (idx + 1);
 }  /* SplitIntoNameAndData */
-
 
 
 
@@ -370,16 +366,12 @@ public:
 
 
 
-
 void  ParticleEntryList::SortByScanLine ()
 {
   ScanLinePredecessor  pr;
   sort (begin (), end (), pr);
   sortedByScanLine = true;
 }  /* SortByScanLine */
-
-
-
 
 
 
@@ -610,7 +602,6 @@ ParticleEntryPtr  ParticleEntryList::ParseParticleImageLine (const KKStr&  value
 
 
    
-
 void  ParticleEntryList::LoadFile (RunLog&  _log)
 {
   scannerFileRootName = osGetRootName (scannerFileName);
@@ -634,7 +625,7 @@ void  ParticleEntryList::LoadFile (RunLog&  _log)
   while  (!sr->eof ())
   {
     KKStr l = buff;
-    if  ((l.Len () < 3)  ||  (l.SubStrPart (0, 1) == "//"))
+    if  ((l.Len () < 3)  ||  (l.StartsWith ("//")))
       continue;
 
     KKStr  name = "";
@@ -721,7 +712,6 @@ void  ParticleEntryList::LoadFile (RunLog&  _log)
 
 
 
-
 MLClassListPtr  ParticleEntryList::ExtractListOfClasses ()  const
 {
   MLClassListPtr  classes = new MLClassList ();
@@ -775,7 +765,6 @@ VectorFloatPtr  ParticleEntryList::CountFrequencyByTimeIntervals (int    interva
 
   return  freqHistogram;
 }  /* CountFrequencyByTimeIntervals  */
-
 
 
 
@@ -870,7 +859,6 @@ VectorFloatPtr  ParticleEntryList::FlowRateByTimeIntervals (int    interval,
 
   return  flowRateByIntervals;
 }  /* FlowRateByTimeIntervals  */
-
 
 
 
@@ -969,6 +957,7 @@ ParticleEntryBuffer::~ParticleEntryBuffer ()
   GoalKeeperSimple::Destroy (goalie);  
   goalie = NULL;
 }
+
 
 
 kkMemSize  ParticleEntryBuffer::MemoryConsumedEstimated ()  const
@@ -1090,10 +1079,8 @@ void  ParticleEntryBuffer::StartBlock ()
 }
 
 
+
 void  ParticleEntryBuffer::EndBlock ()
 {
   goalie->EndBlock ();
 }
-
-
-

--- a/LarcosLibraries/LarcosCounterUnManaged/PostLarvaeFV.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/PostLarvaeFV.cpp
@@ -1410,7 +1410,7 @@ PostLarvaeFVListPtr  PostLarvaeFVList::DuplicateListAndContents ()  const
 {
   PostLarvaeFVListPtr  copyiedList = new PostLarvaeFVList (FileDesc (), true);
 
-  for  (kkint32 idx = 0;  idx < QueueSize ();  idx++)
+  for  (kkuint32 idx = 0;  idx < QueueSize ();  idx++)
   {
     PostLarvaeFVPtr  curImage = (PostLarvaeFVPtr)IdxToPtr (idx);
     copyiedList->AddSingleImageFeatures (new PostLarvaeFV (*curImage));

--- a/LarcosLibraries/LarcosCounterUnManaged/PostLarvaeFV.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/PostLarvaeFV.cpp
@@ -1,9 +1,7 @@
 #include "FirstIncludes.h"
-
 #include <ctype.h>
 #include <math.h>
 #include <time.h>
-
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -11,11 +9,8 @@
 #include <vector>
 #include <string.h>
 #include <typeinfo>
-
 #include "MemoryDebug.h"
-
 using namespace  std;
-
 
 #include "KKBaseTypes.h"
 #include "Blob.h"
@@ -25,12 +20,12 @@ using namespace  std;
 #include "DateTime.h"
 #include "ImageIO.h"
 #include "KKException.h"
+#include "Option.h"
 #include "OSservices.h"
 #include "Raster.h"
 #include "RunLog.h"
 #include "KKStr.h"
 using namespace  KKB;
-
 
 #include "FeatureNumList.h"
 #include "FeatureFileIO.h"
@@ -627,13 +622,13 @@ void  PostLarvaeFV::ParseImageFileName (const KKStr&  fullFileName,
   auto  x = rootName.LocateLastOccurrence ('_');
   if  (x  &&  (x.value () > 0))
   {
-    KKStr  colStr = rootName.SubStrPart (x.value () + 1);
-    KKStr  temp = rootName.SubStrPart (0, x.value () - 1);
+    KKStr  colStr = rootName.SubStrPart (x);
+    KKStr  temp = rootName.SubStrSeg (0, x);
     x = temp.LocateLastOccurrence ('_');
     if  (x  &&  (x.value () > 0))
     {
-      scannerFileName = temp.SubStrPart (0, x.value () - 1);
-      KKStr  rowStr = temp.SubStrPart (x.value () + 1);
+      scannerFileName = temp.SubStrSeg (0, x);
+      KKStr  rowStr = temp.SubStrPart (x + 1);
       scanCol     = atoi (colStr.Str ());
       scanLineNum = atoi (rowStr.Str ());
     }

--- a/LarcosLibraries/LarcosCounterUnManaged/ShrimpLengthComputer.cpp
+++ b/LarcosLibraries/LarcosCounterUnManaged/ShrimpLengthComputer.cpp
@@ -491,7 +491,7 @@ void  ShrimpLengthComputer::ProcessImage (RasterPtr  origImage,
       {
         demoImage = origImage->ToColor ();
 
-        for  (kkint32 x = 1;  x < centerPoints->QueueSize ();  ++x)
+        for  (kkuint32 x = 1;  x < centerPoints->QueueSize ();  ++x)
         {
           PointPtr p1 = centerPoints->IdxToPtr (x - 1);
           PointPtr p2 = centerPoints->IdxToPtr (x);


### PR DESCRIPTION
1. Implemented XmlElementArray as template allowing for generic ToUint32 array return for all data types.
2. All XmlElementArray sub classes now subclass from XmlElementArrayBase.
3 . KKQueue now returns OptionUInt32 for PtrToIdx and other locate methods; rather than using -1 as a flag.
4.. Added OptionUint32 as valid parameter to KKStr::SubStrPart and new KKStr::SubStrSeg methods.
Added